### PR TITLE
fix(notifynl-omc-nodep): add missing mijnOverheid default values

### DIFF
--- a/notifynl-omc-nodep/Chart.yaml
+++ b/notifynl-omc-nodep/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: notifynl-omc-nodep
-version: "0.15.1"
+version: "0.15.2"
 appVersion: "2.0.1"
 kubeVersion: ">=1.26.6"
 description: "Chart to deploy the NotifyNL OMC application."

--- a/notifynl-omc-nodep/README.md
+++ b/notifynl-omc-nodep/README.md
@@ -1,6 +1,6 @@
 # notifynl-omc-nodep
 
-![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 0.15.2](https://img.shields.io/badge/Version-0.15.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 
 Chart to deploy the NotifyNL OMC application.
 
@@ -53,6 +53,10 @@ Kubernetes: `>=1.26.6`
 | settings.kto.auth.jwt.secret | string | `""` | The secret key used for signing JWT tokens for authentication |
 | settings.kto.caseTypeSettings | string | `nil` |  |
 | settings.kto.url | string | `nil` | The API endpoint for submitting case data to KTO |
+| settings.mijnOverheid.auth.clientId | string | `""` | Client identifier registered for OAuth2 authentication with MijnOverheid |
+| settings.mijnOverheid.auth.secret | string | `""` | Client secret used for OAuth2 token exchange with MijnOverheid |
+| settings.mijnOverheid.auth.token.endpoint | string | `nil` | Token endpoint URL used to obtain OAuth2 access tokens for MijnOverheid |
+| settings.mijnOverheid.webhook.url | string | `nil` | Webhook URL that ZGW CloudEvents are forwarded to on MijnOverheid's side |
 | settings.notify.api.baseUrl | string | `"https://api.notifynl.nl"` |  |
 | settings.notify.api.key | string | `nil` |  |
 | settings.notify.templateId.decisionMade | string | `nil` | Should be generated per specific business use case from "Notify NL" Admin Portal |

--- a/notifynl-omc-nodep/values.yaml
+++ b/notifynl-omc-nodep/values.yaml
@@ -182,3 +182,15 @@ settings:
       pem:
         # -- Absolute path to the PEM-encoded private key corresponding to the BRP client certificate
         path: ""
+  mijnOverheid:
+    auth:
+      # -- Client identifier registered for OAuth2 authentication with MijnOverheid
+      clientId: ""
+      # -- Client secret used for OAuth2 token exchange with MijnOverheid
+      secret: ""
+      token:
+        # -- Token endpoint URL used to obtain OAuth2 access tokens for MijnOverheid
+        endpoint:
+    webhook:
+      # -- Webhook URL that ZGW CloudEvents are forwarded to on MijnOverheid's side
+      url:


### PR DESCRIPTION
## Summary
- `notifynl-omc-nodep`'s `secret.yaml`/`configmap.yaml` reference `.Values.settings.mijnOverheid.auth.clientId`, `.auth.secret`, `.auth.token.endpoint`, and `.webhook.url` for the new MijnOverheid CloudEvent forwarding feature. `values.schema.json` already documents this block, but `values.yaml` never defined the corresponding defaults.
- Any release that doesn't explicitly `--set`/override these keys fails template render/upgrade with `nil pointer evaluating interface {}.auth`. This is currently breaking the NotifyNL-OMC repo's own PR-triggered auto-deploy job.
- Adds the missing `settings.mijnOverheid` default block (all empty/null, matching schema) and bumps the chart version to 0.15.2.

## Test plan
- [x] `helm template omc notifynl-omc-nodep/` with representative `--set` overrides renders successfully (previously failed with nil pointer)
- [ ] Re-run the failing deploy job on NotifyNL-OMC PR #210 once this merges/publishes