### PR TITLE
Add the print (printstraat) scenario's settings to notifynl-omc-nodep

### DIFF
--- a/notifynl-omc-nodep/Chart.yaml
+++ b/notifynl-omc-nodep/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: notifynl-omc-nodep
-version: "0.16.0"
+version: "0.16.1"
 appVersion: "2.0.1"
 kubeVersion: ">=1.26.6"
 description: "Chart to deploy the NotifyNL OMC application."

--- a/notifynl-omc-nodep/README.md
+++ b/notifynl-omc-nodep/README.md
@@ -1,6 +1,6 @@
 # notifynl-omc-nodep
 
-![Version: 0.15.3](https://img.shields.io/badge/Version-0.15.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 0.16.1](https://img.shields.io/badge/Version-0.16.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 
 Chart to deploy the NotifyNL OMC application.
 
@@ -60,11 +60,14 @@ Kubernetes: `>=1.26.6`
 | settings.notify.api.baseUrl | string | `"https://api.notifynl.nl"` |  |
 | settings.notify.api.key | string | `nil` |  |
 | settings.notify.templateId.decisionMade | string | `nil` | Should be generated per specific business use case from "Notify NL" Admin Portal |
+| settings.notify.templateId.email.messageBox | string | `nil` | Should be generated per specific business use case from "Notify NL" Admin Portal. MOBB/Berichtenbox digitale-post fallback only - no SMS equivalent exists. |
 | settings.notify.templateId.email.messageReceived | string | `nil` | Should be generated per specific business use case from "Notify NL" Admin Portal |
 | settings.notify.templateId.email.taskAssigned | string | `nil` | Should be generated per specific business use case from "Notify NL" Admin Portal |
 | settings.notify.templateId.email.zaakClose | string | `nil` | Should be generated per specific business use case from "Notify NL" Admin Portal |
 | settings.notify.templateId.email.zaakCreate | string | `nil` | Should be generated per specific business use case from "Notify NL" Admin Portal |
 | settings.notify.templateId.email.zaakUpdate | string | `nil` | Should be generated per specific business use case from "Notify NL" Admin Portal |
+| settings.notify.templateId.letter.messageBox | string | `nil` | Should be generated per specific business use case from "Notify NL" Admin Portal. MOBB/Berichtenbox postal-letter fallback. |
+| settings.notify.templateId.sms.<<.messageBox | string | `nil` | Should be generated per specific business use case from "Notify NL" Admin Portal. MOBB/Berichtenbox digitale-post fallback only - no SMS equivalent exists. |
 | settings.notify.templateId.sms.<<.messageReceived | string | `nil` | Should be generated per specific business use case from "Notify NL" Admin Portal |
 | settings.notify.templateId.sms.<<.taskAssigned | string | `nil` | Should be generated per specific business use case from "Notify NL" Admin Portal |
 | settings.notify.templateId.sms.<<.zaakClose | string | `nil` | Should be generated per specific business use case from "Notify NL" Admin Portal |
@@ -89,22 +92,28 @@ Kubernetes: `>=1.26.6`
 | settings.zgw.auth.key.objectTypen | string | `nil` | It needs to be generated from "ObjectTypen" Web API service UI |
 | settings.zgw.auth.key.objecten | string | `nil` | It needs to be generated from "Objecten" Web API service UI |
 | settings.zgw.auth.key.openklant | string | `nil` | It needs to be generated for OMC Workflow v2 and above from "OpenKlant" 2.0 Web API service UI |
+| settings.zgw.auth.key.openvtb | string | `nil` | It needs to be generated from "Open VTB" Web API service UI. Required only if the MOBB/Berichtenbox scenario is used. |
 | settings.zgw.endpoint.besluiten | string | `nil` | You have to use the domain part from URLs where you are hosting the dedicated Open services, without slash at the end |
 | settings.zgw.endpoint.contactMomenten | string | `nil` | You have to use the domain part from URLs where you are hosting the dedicated Open services, without slash at the end |
+| settings.zgw.endpoint.documenten | string | `nil` | You have to use the domain part from URLs where you are hosting the dedicated Open services, without slash at the end. MOBB fetches real attachment content from here. |
 | settings.zgw.endpoint.objectTypen | string | `nil` | You have to use the domain part from URLs where you are hosting the dedicated Open services, without slash at the end |
 | settings.zgw.endpoint.objecten | string | `nil` | You have to use the domain part from URLs where you are hosting the dedicated Open services, without slash at the end |
 | settings.zgw.endpoint.openKlant | string | `nil` | You have to use the domain part from URLs where you are hosting the dedicated Open services, without slash at the end |
 | settings.zgw.endpoint.openNotificaties | string | `nil` | You have to use the domain part from URLs where you are hosting the dedicated Open services, without slash at the end |
+| settings.zgw.endpoint.openVtb | string | `nil` | You have to use the domain part from URLs where you are hosting the dedicated Open services, without slash at the end. Required only if the MOBB/Berichtenbox scenario is used. |
 | settings.zgw.endpoint.openZaak | string | `nil` | You have to use the domain part from URLs where you are hosting the dedicated Open services, without slash at the end |
 | settings.zgw.urn | string | `nil` | Urn identifying this OMC instance (OIN/RSIN) as the source of outgoing CloudEvents, e.g. "urn:nld:oin:{OIN}:{applicatie}" |
 | settings.zgw.variable.objectType.decisionInfoObjectType.uuids | string | `nil` | Is provided by the user based on "informatieobjecttype" from "informatieobject" retrieved from "OpenZaak" Web API service when querying "besluiten" |
 | settings.zgw.variable.objectType.ktoObjectType.uuid | string | `nil` |  |
 | settings.zgw.variable.objectType.messageObjectType.uuid | string | `nil` | Is provided by the user based on "objectType" from "kenmerken" from the initial notification received from "Notificaties" Web API service |
 | settings.zgw.variable.objectType.messageObjectType.version | int | `2` | It can be taken from "version" value set in "ObjectTypen" Web API service |
+| settings.zgw.variable.objectType.printObjectType.uuid | string | `nil` | Is provided by the user based on "objectType" from "kenmerken" from the initial notification received from "Notificaties" Web API service. Required only if the print (printstraat) scenario is used. |
 | settings.zgw.variable.objectType.taskObjectType.uuid | string | `nil` | Is provided by the user based on "objectType" from "kenmerken" from the initial notification received from "Notificaties" Web API service |
 | settings.zgw.whitelist.decisionMade.ids | string | `"*"` | Is provided by the user based on "Identificatie" property of case type retrieved from case URI ("zaak") from "OpenZaak" Web API service |
 | settings.zgw.whitelist.message.allowed | bool | `true` | Is provided by the user |
+| settings.zgw.whitelist.print.allowed | bool | `false` | Is provided by the user. Off by default: enabling it lets any object of the print objecttype be printed and posted, so it should be switched on deliberately per environment |
 | settings.zgw.whitelist.taskAssigned.ids | string | `"*"` | Is provided by the user based on "Identificatie" property of case type retrieved from case URI ("zaak") from "OpenZaak" Web API service |
+| settings.zgw.whitelist.vtbMessage.types | string | `"*"` | Is provided by the user based on the CloudEvent "type" received from "Open VTB" Web API service |
 | settings.zgw.whitelist.zaakClose.ids | string | `"*"` | Is provided by the user based on "Identificatie" property of case type retrieved from case URI ("zaak") from "OpenZaak" Web API service |
 | settings.zgw.whitelist.zaakCreate.ids | string | `"*"` | Is provided by the user based on "Identificatie" property of case type retrieved from case URI ("zaak") from "OpenZaak" Web API service |
 | settings.zgw.whitelist.zaakUpdate.ids | string | `"*"` | Is provided by the user based on "Identificatie" property of case type retrieved from case URI ("zaak") from "OpenZaak" Web API service |

--- a/notifynl-omc-nodep/templates/configmap.yaml
+++ b/notifynl-omc-nodep/templates/configmap.yaml
@@ -38,6 +38,7 @@ data:
   ZGW_VARIABLE_OBJECTTYPE_MESSAGEOBJECTTYPE_VERSION: {{ default 2 .Values.settings.zgw.variable.objectType.messageObjectType.version | quote }}
   ZGW_VARIABLE_OBJECTTYPE_DECISIONINFOOBJECTTYPE_UUIDS: {{ default "" .Values.settings.zgw.variable.objectType.decisionInfoObjectType.uuids | quote }}
   ZGW_VARIABLE_OBJECTTYPE_KTOOBJECTTYPE_UUID: {{ default "" .Values.settings.zgw.variable.objectType.ktoObjectType.uuid | quote }}
+  ZGW_VARIABLE_OBJECTTYPE_PRINTOBJECTTYPE_UUID: {{ default "" .Values.settings.zgw.variable.objectType.printObjectType.uuid | quote }}
   ZGW_WHITELIST_ZAAKCREATE_IDS: {{ default "*" .Values.settings.zgw.whitelist.zaakCreate.ids | quote }}
   ZGW_WHITELIST_ZAAKUPDATE_IDS: {{ default "*" .Values.settings.zgw.whitelist.zaakUpdate.ids | quote }}
   ZGW_WHITELIST_ZAAKCLOSE_IDS: {{ default "*" .Values.settings.zgw.whitelist.zaakClose.ids | quote }}
@@ -45,6 +46,7 @@ data:
   ZGW_WHITELIST_DECISIONMADE_IDS: {{ default "*" .Values.settings.zgw.whitelist.decisionMade.ids | quote }}
   ZGW_WHITELIST_MESSAGE_ALLOWED: {{ default "true" .Values.settings.zgw.whitelist.message.allowed | quote }}
   ZGW_WHITELIST_VTBMESSAGE_TYPES: {{ default "*" .Values.settings.zgw.whitelist.vtbMessage.types | quote }}
+  ZGW_WHITELIST_PRINT_ALLOWED: {{ default "false" .Values.settings.zgw.whitelist.print.allowed | quote }}
   NOTIFY_API_BASEURL: {{ .Values.settings.notify.api.baseUrl }}
   NOTIFY_TEMPLATEID_DECISIONMADE: {{ default "" .Values.settings.notify.templateId.decisionMade }}
   NOTIFY_TEMPLATEID_EMAIL_ZAAKCREATE: {{ .Values.settings.notify.templateId.email.zaakCreate }}

--- a/notifynl-omc-nodep/values.schema.json
+++ b/notifynl-omc-nodep/values.schema.json
@@ -431,6 +431,14 @@
 													"$ref": "#/definitions/uuid"
 												}
 											}
+										},
+										"printObjectType": {
+											"type": "object",
+											"properties": {
+												"uuid": {
+													"$ref": "#/definitions/uuid"
+												}
+											}
 										}
 									}
 								}
@@ -485,6 +493,15 @@
 										"allowed": {
 											"type": "boolean",
 											"default": true
+										}
+									}
+								},
+								"print": {
+									"type": "object",
+									"properties": {
+										"allowed": {
+											"type": "boolean",
+											"default": false
 										}
 									}
 								}

--- a/notifynl-omc-nodep/values.yaml
+++ b/notifynl-omc-nodep/values.yaml
@@ -149,6 +149,10 @@ settings:
       vtbMessage:
         # -- Is provided by the user based on the CloudEvent "type" received from "Open VTB" Web API service
         types: "*"
+      print:
+        # -- Is provided by the user. Off by default: enabling it lets any object of the print objecttype
+        # be printed and posted, so it should be switched on deliberately per environment
+        allowed: false
     variable:
       objectType:
         taskObjectType:
@@ -163,6 +167,9 @@ settings:
           # -- Is provided by the user based on "informatieobjecttype" from "informatieobject" retrieved from "OpenZaak" Web API service when querying "besluiten"
           uuids:
         ktoObjectType:
+          uuid:
+        printObjectType:
+          # -- Is provided by the user based on "objectType" from "kenmerken" from the initial notification received from "Notificaties" Web API service. Required only if the print (printstraat) scenario is used.
           uuid:
   kto:
     auth:


### PR DESCRIPTION
Adds the two settings the print/printstraat scenario needs, for [NotifyNL-OMC#237](https://github.com/Worth-NL/NotifyNL-OMC/issues/237) (Jira MBO-1025).

| Setting | Env var | Default |
|---|---|---|
| `settings.zgw.whitelist.print.allowed` | `ZGW_WHITELIST_PRINT_ALLOWED` | `false` |
| `settings.zgw.variable.objectType.printObjectType.uuid` | `ZGW_VARIABLE_OBJECTTYPE_PRINTOBJECTTYPE_UUID` | `""` |

Both are inert by default — existing deployments upgrade with the print flow off, and it has to be switched on deliberately per environment along with the objecttype UUID.

Chart version bumped `0.16.0` → `0.16.1`. `values.schema.json` updated to match. `README.md` is left for the helm-docs action to regenerate.

Verified with `helm template`: defaults render as `"false"` / `""`, and overrides render correctly and pass schema validation.

### Note for review

The helm-docs action will also sweep six unrelated rows into the README when it regenerates — `endpoint.documenten`, `endpoint.openVtb`, `auth.key.openvtb`, `email.messageBox`, `letter.messageBox` and `whitelist.vtbMessage.types`. Those are pre-existing MOBB/VTB settings that were never documented, not part of this change.